### PR TITLE
Add validation restrictions to account name constructor function

### DIFF
--- a/kadena-signing-api/kadena-signing-api.cabal
+++ b/kadena-signing-api/kadena-signing-api.cabal
@@ -41,3 +41,15 @@ executable gen-docs
     , base
     , bytestring ^>= 0.10
     , kadena-signing-api
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: main.hs
+  hs-source-dirs: tests
+  if impl(ghcjs)
+    buildable: False
+  build-depends:
+      hedgehog
+    , base
+    , text >= 1.0 && < 1.3
+    , kadena-signing-api

--- a/kadena-signing-api/src/Kadena/SigningApi.hs
+++ b/kadena-signing-api/src/Kadena/SigningApi.hs
@@ -16,6 +16,7 @@ import Data.Swagger
 import qualified Data.Swagger as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Char as Char
 import GHC.Generics
 import Pact.Server.API
 import NeatInterpolation
@@ -43,9 +44,21 @@ this will be the account used to pay the transaction's gas price.
 -- | Smart constructor for account names. The only restriction in the coin
 -- contract (as it stands) appears to be that accounts can't be an empty string
 mkAccountName :: Text -> Either Text AccountName
-mkAccountName n
-  | T.null n = Left "Account name must not be empty"
-  | otherwise = Right $ AccountName n
+mkAccountName n =
+  if not isValidCharset then Left "Invalid Character detected. Must be Latin1, no spaces, control characters or '|'"
+  else if not isCorrectSize then Left "Incorrect length. Must be between 3 and 256 characters in length."
+  else Right $ AccountName n
+  where
+    isValidCharset = T.foldl' (\b c -> b && isValidAccountNameCharacter c) True n
+    isCorrectSize = let l = T.length n in l >= 3 && l <= 256
+
+isValidAccountNameCharacter :: Char -> Bool
+isValidAccountNameCharacter char = Char.isLatin1 char
+  && not ( Char.isSpace char ||
+           Char.isControl char ||
+           char == '|' ||
+           char == '\NUL'
+         )
 
 -- | Values of this type are supplied by the dapp author to the wallet so the
 -- wallet knows what capabilities need to be granted for the transaction.

--- a/kadena-signing-api/src/Kadena/SigningApi.hs
+++ b/kadena-signing-api/src/Kadena/SigningApi.hs
@@ -53,7 +53,7 @@ isCorrectSize :: Text -> Bool
 isCorrectSize n = let l = T.length n in l >= 3 && l <= 256
 
 isValidCharset :: Text -> Bool
-isValidCharset = T.foldl' (\b c -> b && isValidAccountNameCharacter c) True
+isValidCharset = T.all isValidAccountNameCharacter
 
 isValidAccountNameCharacter :: Char -> Bool
 isValidAccountNameCharacter char = Char.isLatin1 char

--- a/kadena-signing-api/src/Kadena/SigningApi.hs
+++ b/kadena-signing-api/src/Kadena/SigningApi.hs
@@ -45,12 +45,15 @@ this will be the account used to pay the transaction's gas price.
 -- contract (as it stands) appears to be that accounts can't be an empty string
 mkAccountName :: Text -> Either Text AccountName
 mkAccountName n =
-  if not isValidCharset then Left "Invalid Character detected. Must be Latin1, no spaces, control characters or '|'"
-  else if not isCorrectSize then Left "Incorrect length. Must be between 3 and 256 characters in length."
+  if not (isValidCharset n) then Left "Invalid Character detected. Must be Latin1, no spaces, control characters or '|'"
+  else if not (isCorrectSize n) then Left "Incorrect length. Must be between 3 and 256 characters in length."
   else Right $ AccountName n
-  where
-    isValidCharset = T.foldl' (\b c -> b && isValidAccountNameCharacter c) True n
-    isCorrectSize = let l = T.length n in l >= 3 && l <= 256
+
+isCorrectSize :: Text -> Bool
+isCorrectSize n = let l = T.length n in l >= 3 && l <= 256
+
+isValidCharset :: Text -> Bool
+isValidCharset = T.foldl' (\b c -> b && isValidAccountNameCharacter c) True
 
 isValidAccountNameCharacter :: Char -> Bool
 isValidAccountNameCharacter char = Char.isLatin1 char

--- a/kadena-signing-api/tests/main.hs
+++ b/kadena-signing-api/tests/main.hs
@@ -17,17 +17,17 @@ prop_accountname_valid = property $ do
   nom <- forAll $ Gen.text (Range.linear 0 300) Gen.unicode
   let acc = mkAccountName nom
       len = T.length nom
-      anyInvalid = isValidCharset nom
+      allValid = isValidCharset nom
 
   classify "valid length" (len >= 3 && len <= 256)
   classify "invalid length" (len < 3 || len > 256)
-  classify "valid chars" (not anyInvalid)
-  classify "invalid chars" anyInvalid
+  classify "valid chars" allValid
+  classify "invalid chars" (not allValid)
 
   if isRight acc then
     if len < 3 then annotate "Minimum length < 3" *> failure
     else if len > 256 then annotate "Maximum length > 256" *> failure
-    else if anyInvalid then annotate "Invalid characters detected" *> failure
+    else if not allValid then annotate "Invalid characters detected" *> failure
     else success -- We've created an AccountName that meets the requirements
     else success -- We've avoided creating an invalid AccountName
 

--- a/kadena-signing-api/tests/main.hs
+++ b/kadena-signing-api/tests/main.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Control.Monad (when)
+import Data.Either (isLeft, isRight)
+import qualified Data.Char as Char
+import qualified Data.Text as T
+
+import Kadena.SigningApi (mkAccountName,isValidAccountNameCharacter)
+
+prop_accountname_valid :: Property
+prop_accountname_valid = property $ do
+  nom <- forAll $ Gen.text (Range.linear 0 300) Gen.unicode
+  let acc = mkAccountName nom
+      len = T.length nom
+      anyInvalid = not $ T.foldl' (\b c -> b && isValidAccountNameCharacter c) True nom
+
+  classify "valid length" (len >= 3 && len <= 256)
+  classify "invalid length" (len < 3 || len > 256)
+  classify "valid chars" (not anyInvalid)
+  classify "invalid chars" anyInvalid
+
+  if isRight acc then
+    if len < 3 then annotate "Minimum length < 3" *> failure
+    else if len > 256 then annotate "Maximum length > 256" *> failure
+    else if anyInvalid then annotate "Invalid characters detected" *> failure
+    else success -- We've created an AccountName that meets the requirements
+    else success -- We've avoided creating an invalid AccountName
+
+main :: IO Bool
+main = checkParallel $$(discover)

--- a/kadena-signing-api/tests/main.hs
+++ b/kadena-signing-api/tests/main.hs
@@ -10,14 +10,14 @@ import Data.Either (isLeft, isRight)
 import qualified Data.Char as Char
 import qualified Data.Text as T
 
-import Kadena.SigningApi (mkAccountName,isValidAccountNameCharacter)
+import Kadena.SigningApi (mkAccountName,isValidCharset)
 
 prop_accountname_valid :: Property
 prop_accountname_valid = property $ do
   nom <- forAll $ Gen.text (Range.linear 0 300) Gen.unicode
   let acc = mkAccountName nom
       len = T.length nom
-      anyInvalid = not $ T.foldl' (\b c -> b && isValidAccountNameCharacter c) True nom
+      anyInvalid = isValidCharset nom
 
   classify "valid length" (len >= 3 && len <= 256)
   classify "invalid length" (len < 3 || len > 256)


### PR DESCRIPTION
The `AccountName` must be within the Latin1 charset, not containing spaces or control characters or currently the `|` character. Added tests to validate the checks.