### PR TITLE
Fix structural issue in CommandSigData spec

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -218,13 +218,10 @@ definitions:
     properties:
       sigs:
         items:
-          - items:
-              type: string
-            type: array
-          - items:
-              - type: string
-              - type: "null"
-            type: array
+          items:
+            type: string
+            x-nullable: true
+          type: array
         type: array
       cmd:
         type: string


### PR DESCRIPTION
This PR is the first step of #23.

The purpose here is to fix the structural issues of the existing `swagger.yaml` before converting it to OAS 3 so that we have a more faithful conversion.

Strangely enough, the `swagger-cli` doesn't report any errors with the existing `swagger.yaml`, but editor.swagger.io reports the following:

![image](https://user-images.githubusercontent.com/1258139/223142214-bc2a8121-d7a0-45fb-8bb9-8a7d167d7091.png)

Adding further to the strangeness, editor-next.swagger.io, the new editor from swagger also doesn't report any errors, but it's interpreting the `sigs` schema in a nonsensical way:

![image](https://user-images.githubusercontent.com/1258139/223142722-5270d6ef-7f81-47b3-b5f2-fc1a5a4d6cdc.png)

I.e. it thinks `sigs` is an array of objects without any properties.

This PR tries to widen the type a little bit to be less precise but at least withing the boundaries of Swagger 2.0 so that the editor interprets it as:

![image](https://user-images.githubusercontent.com/1258139/223143272-168fbe03-e92e-47f8-b272-92b250ad3e68.png)

I.e. an array of array of strings (marked as nullable by an extension :shrug:).